### PR TITLE
Format true floating point (no implied decimals) as 'g' (general) rat…

### DIFF
--- a/lib/syntax_file/controller.rb
+++ b/lib/syntax_file/controller.rb
@@ -6,7 +6,7 @@
 module SyntaxFile
 class Controller
 
-VERSION = "1.1.0"
+VERSION = "1.1.2"
 
 ATTR = {
     :project                    => { :req => false, :rw => 'rw', :def => '',          :yaml => true  },

--- a/lib/syntax_file/maker_stata.rb
+++ b/lib/syntax_file/maker_stata.rb
@@ -16,7 +16,9 @@ def initialize (sfc, syntax_type)
     @var_lab_format     = "label var %-#{mx_var}s %s"
     @infix_format       = "%#{mx_col + mx_var + 4}s"
     @replace_format     = "replace %-#{mx_var}s = %-#{mx_var}s / %d"
-    @display_format     = "format %-#{mx_var}s %%%d.%df"
+    @fixed_point_display_format     = "format %-#{mx_var}s %%%d.%df"
+	@general_display_format = "format %-#{mx_var}s %%%d.%dg"
+	
     @cmd_end            = ''
     @cmd_continue       = ' ///'
     @var_label_max_leng = 80
@@ -203,7 +205,14 @@ def syn_display_format
     return [] if var_list.empty?
     var_list.map { |var|
         v = var.name.downcase
-        sprintf @display_format, v, var.width, var.implied_decimals
+		
+		# If implied decimals set, it means we know exactly how much precision
+		# to show. Otherwise we go with the underlying value and the 'g' (general) formatting rules in Stata
+        formatting = var.implied_decimals > 0 ?
+			sprintf(@fixed_point_display_format, v, var.width, var.implied_decimals) :
+			sprintf(@general_display_format, v, var.width, var.implied_decimals)
+			
+		formatting
     }
 end
 

--- a/tests/tc_maker_stata.rb
+++ b/tests/tc_maker_stata.rb
@@ -145,7 +145,7 @@ def test_syn_display_format
         "format canton   %3.1f",
         "format resprev2 %4.3f",
         "format bigdec   %10.5f",
-        "format bigint   %19.0f"
+        "format bigint   %19.0g"
     ]
     actual = mk.syn_display_format
     assert_equal expected, actual, msg


### PR DESCRIPTION
…her than 'f' (fixed)

Tests pass. I changed one test case to look for 'g' instead of 'f'. 

Basically the change involves making the Stata script use the 'g' format type when a variable is 'double' (data_type == 'double') and it has no implied decimals. Stata scripts will still get set to 'double' type even when the metadata has no 'double' type set and it is a default integer, as long as implied decimals >0. In those cases the format type is 'f' (fixed type) and the format is like COLUMN_WIDTH.IMPLIED_DECIMALSf.