### PR TITLE
Add support for IPUMS integer variables in Stata

### DIFF
--- a/lib/syntax_file/controller.rb
+++ b/lib/syntax_file/controller.rb
@@ -6,7 +6,7 @@
 module SyntaxFile
   class Controller
 
-    VERSION = "1.1.7"
+    VERSION = "1.1.8"
 
     ATTR = {
       :project                    => { :req => false, :rw => 'rw', :def => '',          :yaml => true  },

--- a/tests/tc_maker_stata.rb
+++ b/tests/tc_maker_stata.rb
@@ -145,7 +145,7 @@ def test_syn_display_format
         "format canton   %3.1f",
         "format resprev2 %4.3f",
         "format bigdec   %10.5f",
-        "format bigint   %19.0g"
+        "format bigint   %19.0f"
     ]
     actual = mk.syn_display_format
     assert_equal expected, actual, msg


### PR DESCRIPTION
- When implied decimals are set, it means we know exactly how much precision to show: '.nf' where n is the number of implied decimals.
- When the number is a double float in our metadata, we go with the underlying value and the '.0g' (general) formatting rules in Stata.
- Otherwise the variable is a integer in our metadata, and we therefore use '.0f' for formatting.

This functionality was released in gem 1.1.6 but was never committed to
the repository, and was therefore lost when version 1.1.7 was released.